### PR TITLE
feat: bump version to 2.0.2 to force Home Assistant image rebuild

### DIFF
--- a/face-rekon/config.json
+++ b/face-rekon/config.json
@@ -1,19 +1,12 @@
 {
   "name": "Face Rekon",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "slug": "face_rekon",
   "description": "AI-powered face recognition with comprehensive web UI for managing and labeling faces. Features real-time detection, FAISS similarity search, and seamless Home Assistant integration.",
   "startup": "application",
-  "arch": [
-    "amd64",
-    "armv7",
-    "aarch64"
-  ],
+  "arch": ["amd64", "armv7", "aarch64"],
   "boot": "auto",
-  "map": [
-    "config:rw",
-    "addons:rw"
-  ],
+  "map": ["config:rw", "addons:rw"],
   "host_network": false,
   "ingress": true,
   "ingress_port": 5001,


### PR DESCRIPTION
## Summary
- Bump version from 2.0.1 to 2.0.2 to force Home Assistant to rebuild Docker image
- Ensures HAOS deployments get the latest Qdrant connection fixes from PR #29
- Resolves cached image issue preventing Qdrant integration in production

## Problem
Home Assistant was using a cached Docker image that didn't include the Qdrant connection fixes. This caused the add-on to still fall back to FAISS+TinyDB in production even though the fixes were merged.

## Solution
Version bump forces Home Assistant to:
1. Rebuild the Docker image with latest code
2. Include all Qdrant connection fixes and UUID handling
3. Deploy the corrected production environment

## Testing
- ✅ Local testing confirms Qdrant integration works with rebuilt image
- ✅ Version change triggers automatic rebuilds in HAOS

🤖 Generated with [Claude Code](https://claude.ai/code)