### PR TITLE
fix: resolve Flask reload conflicts with embedded Qdrant

### DIFF
--- a/face-rekon/scripts/app.py
+++ b/face-rekon/scripts/app.py
@@ -484,4 +484,6 @@ def serve_face_image(face_id: str) -> Any:
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5001, debug=True)
+    # Disable debug mode in production to prevent Flask reloader conflicts
+    debug_mode = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(host="0.0.0.0", port=5001, debug=debug_mode)

--- a/face-rekon/scripts/qdrant_adapter.py
+++ b/face-rekon/scripts/qdrant_adapter.py
@@ -66,7 +66,16 @@ class QdrantAdapter:
                 logger.info(f"✅ Connected to embedded Qdrant at {QDRANT_PATH}")
                 return
             except Exception as e:
-                logger.error(f"❌ Failed to initialize embedded Qdrant: {e}")
+                # Check if it's a storage lock conflict (common during Flask reloads)
+                if "already accessed by another instance" in str(e):
+                    logger.warning(
+                        f"⚠️ Qdrant storage locked (likely Flask reload): {e}"
+                    )
+                    logger.info(
+                        "🔄 This is normal during development - falling back to FAISS"
+                    )
+                else:
+                    logger.error(f"❌ Failed to initialize embedded Qdrant: {e}")
                 raise
         else:
             # Use remote server mode (original behavior)


### PR DESCRIPTION
## Summary
- Add graceful error handling for Qdrant storage lock conflicts during Flask reloads
- Disable Flask debug mode in production to prevent multiple process conflicts  
- Make Flask debug mode configurable via FLASK_DEBUG environment variable

## Problem
Flask's stat reloader creates multiple processes that attempt to access the same Qdrant storage folder, causing conflicts with errors like "Storage folder is already accessed by another instance".

## Solution
1. **Enhanced error handling**: Added specific detection for storage lock conflicts in `qdrant_adapter.py` with appropriate warning messages
2. **Production safety**: Modified `app.py` to disable Flask debug mode in production (defaults to `debug=False`)
3. **Development flexibility**: Made debug mode configurable via `FLASK_DEBUG` environment variable for development use

## Changes
- **scripts/qdrant_adapter.py**: Added storage lock conflict detection and graceful error handling
- **scripts/app.py**: Made Flask debug mode configurable and disabled by default

## Test plan
- [x] Verify embedded Qdrant works without conflicts in production mode
- [x] Test that development mode still works when FLASK_DEBUG=true
- [x] Confirm proper error messages for storage conflicts
- [ ] Deploy to Home Assistant and verify no reload conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)