### PR TITLE
chore: configure docker-compose for embedded Qdrant mode

### DIFF
--- a/face-rekon/docker-compose.yml
+++ b/face-rekon/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - FLASK_ENV=development
-      - FLASK_DEBUG=1
-      - QDRANT_HOST=qdrant
-      - QDRANT_PORT=6333
+      - FLASK_DEBUG=false
+      - FACE_REKON_USE_EMBEDDED_QDRANT=true
+      - QDRANT_PATH=/config/face-rekon/qdrant
       - FACE_REKON_USE_QDRANT=true
       - FACE_REKON_SIMILARITY_THRESHOLD=0.35
       - FACE_REKON_BORDERLINE_THRESHOLD=0.50


### PR DESCRIPTION
## Summary
Update docker-compose.yml to use the new embedded Qdrant mode implemented in v2.2.1

## Changes
- Set `FLASK_DEBUG=false` to prevent Flask reloader conflicts
- Enable `FACE_REKON_USE_EMBEDDED_QDRANT=true` for embedded mode
- Add `QDRANT_PATH=/config/face-rekon/qdrant` for storage location
- Remove external Qdrant host/port dependencies

## Benefits
- ✅ No more Flask reload conflicts during development
- ✅ Matches production embedded Qdrant configuration  
- ✅ Simpler local development setup (no external Qdrant service needed)
- ✅ Consistent with Home Assistant deployment model

## Testing
Verified embedded Qdrant works correctly with:
- Clean startup without Flask reloader conflicts
- Successful API responses (`{"pong": true}`)
- Proper embedded storage at `/config/face-rekon/qdrant`

🤖 Generated with [Claude Code](https://claude.ai/code)