### PR TITLE
🔒 fix(ci): upgrade action-download-artifact to v6 to fix artifact poisoning

### DIFF
--- a/.github/workflows/coverage-health.yml
+++ b/.github/workflows/coverage-health.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Download coverage artifacts from CI
         if: steps.pr-info.outputs.event_type == 'workflow_run'
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         with:
           name: ci-coverage-reports
           path: ./coverage-artifacts/


### PR DESCRIPTION
## 🚨 Security Fix

This PR addresses a **high severity artifact poisoning vulnerability** in dawidd6/action-download-artifact v5 and earlier.

## Summary
- Upgrade action-download-artifact from v3 to v6
- Fixes artifact poisoning vulnerability in CI/CD pipeline
- Resolves Dependabot alert #4

## Vulnerability Details
The `dawidd6/action-download-artifact` action versions 5 and earlier are vulnerable to artifact poisoning attacks, allowing potential:
- **Supply chain attacks** via compromised artifacts
- **CI/CD pipeline tampering**
- **Privilege escalation** through malicious artifacts

## Changes Made
- ✅ Updated `.github/workflows/coverage-health.yml`: action-download-artifact v3 → v6

## Security Impact
- 🟠 **Before**: High severity vulnerability (artifact poisoning risk)
- 🟢 **After**: Vulnerability patched, secure artifact handling

## Testing
- [ ] Workflow syntax validation passes
- [ ] Coverage health workflow runs successfully
- [ ] No breaking changes in artifact download behavior
- [ ] Dependabot alert #4 resolved after merge

## References
- **Issue**: Fixes #110
- **Dependabot Alert**: #4
- **Fixed in**: action-download-artifact v6
- **Affected file**: `.github/workflows/coverage-health.yml`

## Priority
🔥 **HIGH** - Security vulnerability requiring prompt merge

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>