### PR TITLE
🔒 Fix ReDoS Vulnerability in Black (CVE-2024-21503)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Code formatting and linting tools
-black==23.7.0
+black==24.3.0
 isort==5.12.0
 flake8==6.0.0
 pylint==2.17.5


### PR DESCRIPTION
## Summary

Fixes #112 - Upgrades Black from 23.7.0 to 24.3.0 to address CVE-2024-21503 (ReDoS vulnerability).

## Changes
- Updated `requirements-dev.txt`: `black==23.7.0` → `black==24.3.0`

## Security Impact
- **Severity**: Medium
- **CVE**: CVE-2024-21503
- **Description**: ReDoS vulnerability in Black's AST safety check
- **Resolution**: Patched in Black 24.3.0

## Testing
- CI checks will verify compatibility with existing codebase
- Black formatting still functions correctly with updated version

## Related
- Resolves Dependabot alert #2
- Part of security vulnerability remediation effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>