### PR TITLE
ci: add disk space optimization to prevent GHA build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,17 @@ jobs:
         python-version: [3.10.18]
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
+      - name: Free disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After cleanup:"
+          df -h
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -126,13 +130,17 @@ jobs:
     # Skip CI for release-please branches
     if: github.head_ref != '' && !startsWith(github.head_ref, 'release-please--') || github.head_ref == ''
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
+      - name: Free disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After cleanup:"
+          df -h
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
         python-version: [3.10.18]
 
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -118,6 +126,14 @@ jobs:
     # Skip CI for release-please branches
     if: github.head_ref != '' && !startsWith(github.head_ref, 'release-please--') || github.head_ref == ''
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Adds `easimon/maximize-build-space` GitHub Action to free up ~15-25GB of disk space during CI builds, preventing "No space left on device" errors when building Docker images with PyTorch.

## Problem

- **Issue**: GitHub Actions fails with "No space left on device" during Docker builds
- **Root cause**: PyTorch installation requires ~4-5GB temporary space during pip install
- **Available space**: GitHub Actions runners have only ~25-29GB free by default
- **Result**: Docker build test job consistently fails in CI

## Solution

Integrated the `easimon/maximize-build-space` action to remove unnecessary pre-installed tools:
- .NET Framework (~10GB)
- Android SDK (~5GB)
- Haskell toolchain (~2GB)
- CodeQL (~2GB)

**Total reclaimed**: ~15-25GB

## Changes

- ✅ Added maximize-build-space step to `test` job (builds Dockerfile.test)
- ✅ Added maximize-build-space step to `docker-build` job (builds production Dockerfile)
- ⏱️ Tradeoff: Adds ~2-3 minutes to CI runtime for cleanup phase

## Testing Plan

- [x] PR created and pushed to trigger CI
- [ ] Monitor "Test Face Rekon" job for successful Docker build
- [ ] Monitor "Docker Build Test" job for successful production build
- [ ] Verify both jobs complete without disk space errors

## Context

This is a **quick fix** to get CI/CD working without changing production deployment. Alternative solutions (custom base image) can be explored later if build time becomes an issue.

Related: PR #173 (Docker optimization for Home Assistant OS - now works in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)